### PR TITLE
Fix substitute crash

### DIFF
--- a/wapihook/Tweak.xm
+++ b/wapihook/Tweak.xm
@@ -1,13 +1,21 @@
+#import <substrate.h>
 //#define FAKE_CHINA
 
-%hookf(CFBooleanRef, "_MGGetBoolAnswer", CFStringRef string)
+Boolean (*old_MGGetBoolAnswer)(CFStringRef);
+Boolean replaced_MGGetBoolAnswer(CFStringRef string)
 {
-	if (CFEqual(string, CFSTR("wapi")) || CFEqual(string, CFSTR("hiHut/WR+B9Lx/vd0WyeNg"))) {
-#ifdef FAKE_CHINA
-		return kCFBooleanTrue;
-#else
-		return kCFBooleanFalse;
-#endif
+    if (CFEqual(string, CFSTR("wapi")) || CFEqual(string, CFSTR("hiHut/WR+B9Lx/vd0WyeNg"))) {
+		#ifdef FAKE_CHINA
+			return true;
+		#else
+			return false;
+		#endif
 	}
-	return %orig;
+	return old_MGGetBoolAnswer(string);
+}
+
+
+%ctor
+{
+	MSHookFunction((void *)(dlsym(RTLD_DEFAULT, "MGGetBoolAnswer")), (void *)replaced_MGGetBoolAnswer, (void **)&old_MGGetBoolAnswer);
 }


### PR DESCRIPTION
test on iOS13.3,XR